### PR TITLE
로직 최적화 및 안정성 개선

### DIFF
--- a/app/v2/config/rate_limit.py
+++ b/app/v2/config/rate_limit.py
@@ -1,0 +1,28 @@
+import datetime
+
+from redis_om import NotFoundError
+
+from app.v2.redis.model.api_call_count import APICallCount
+
+RATE_LIMIT = 300
+TIME_PERIOD = 60 * 60 * 24
+
+
+def check_rate_limit():
+    try:
+        api_call_count = APICallCount.find().first()
+        if api_call_count.count > RATE_LIMIT:
+            return {'status': False, 'count': api_call_count.count, 'message': '금일 할당량을 초과했습니다.'}
+
+        api_call_count.count += 1
+        api_call_count.save()
+        return {'status': True, 'count': api_call_count.count}
+
+    except NotFoundError as e:
+        api_call_count = APICallCount(count=1, last_call=datetime.datetime.now())
+        api_call_count.save()
+        api_call_count.expire(TIME_PERIOD)
+        return {'status': True, 'count': api_call_count.count}
+
+    except Exception as e:
+        return {'status': False, 'count': str(e)}

--- a/app/v2/content/get_content.py
+++ b/app/v2/content/get_content.py
@@ -40,7 +40,7 @@ def create_content(q: str, background_task):
                                                                  keyword_groups)[0]['data']
     estimated_search_amount = get_estimated_search_amount(q, trend_search_data)
 
-    a = collect_issues(q, estimated_search_amount)
+    a = collect_issues(q)
     b = create_embedding_result(a)
     c = cluster_issues(b)
     d = create_group_title(c)

--- a/app/v2/content/issue_info.py
+++ b/app/v2/content/issue_info.py
@@ -13,8 +13,8 @@ from app.v2.external_request.request_news_comments import RequestNewsComments
 def collect_issues(q: str):
     naver_news_response = get_naver_news(q, 100, 1, sort='sim')
     news_items = naver_news_response.json().get('items', [])
-    news_items = [news_item for news_item in news_items if
-                  news_item['link'].startswith('https://n.news.naver.com/mnews/article')]
+    # news_items = [news_item for news_item in news_items if
+    #               news_item['link'].startswith('https://n.news.naver.com/mnews/article')]
 
     news_items = sorted(news_items, key=lambda news_item: RequestNewsComments.get_news_comments_num(news_item['link']), reverse=True)
     return news_items[:20]

--- a/app/v2/content/issue_info.py
+++ b/app/v2/content/issue_info.py
@@ -1,43 +1,23 @@
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime
 
 from sklearn.cluster import DBSCAN
 from sklearn.preprocessing import StandardScaler
 
-from app.v2.content.get_high_searching_news import get_high_searching_days, get_high_searching_news
 from app.v2.external_request import EmbeddingExecutor, get_naver_news, CompletionExecutor, \
     get_news_summary, HCX003Chat
 from app.v2.external_request.request_news_comments import RequestNewsComments
 
 
-def convert_pubDate_format(data):
-    for item in data:
-        try:
-            date_obj = datetime.strptime(item['pubDate'], '%a, %d %b %Y %H:%M:%S %z')
-            item['pubDate'] = date_obj.strftime('%Y%m%d')
-        except ValueError:
-            try:
-                date_obj = datetime.strptime(item['pubDate'], '%Y%m%d')
-                item['pubDate'] = date_obj.strftime('%Y%m%d')
-            except ValueError:
-                continue
-
-
-def collect_issues(q: str, estimated_search_amount: list):
-    #high_searching_news = get_high_searching_news(q, get_high_searching_days(estimated_search_amount))
-
+def collect_issues(q: str):
     naver_news_response = get_naver_news(q, 100, 1, sort='sim')
     news_items = naver_news_response.json().get('items', [])
     news_items = [news_item for news_item in news_items if
                   news_item['link'].startswith('https://n.news.naver.com/mnews/article')]
-    #news_items += high_searching_news
-    convert_pubDate_format(news_items)
 
-    news_items = [news_item for news_item in news_items
-                  if RequestNewsComments.get_news_comments_num(news_item['link']) >= 10]
-    return news_items
+    news_items = sorted(news_items, key=lambda news_item: RequestNewsComments.get_news_comments_num(news_item['link']), reverse=True)
+    return news_items[:20]
 
 
 def create_embedding_result(issues: list):
@@ -57,8 +37,10 @@ def create_embedding_result(issues: list):
         future_to_item = {executor.submit(get_embedding, item): item for item in issues}
         for future in as_completed(future_to_item):
             embedding = future.result()
-            if embedding != "Error":
-                embedding_results.append((embedding, future_to_item[future]))
+            while embedding == "Error":
+                time.sleep(1)
+                embedding = future.result()
+            embedding_results.append((embedding, future_to_item[future]))
 
     return embedding_results
 

--- a/app/v2/content/issue_info.py
+++ b/app/v2/content/issue_info.py
@@ -30,16 +30,17 @@ def create_embedding_result(issues: list):
 
     def get_embedding(item):
         request_data = {"text": item['title']}
-        return embedding_executor.execute(request_data)
+        embedding = embedding_executor.execute(request_data)
+        while embedding == 'Error':
+            embedding = embedding_executor.execute(request_data)
+            time.sleep(1)
+        return embedding
 
     embedding_results = []
     with ThreadPoolExecutor(max_workers=10) as executor:
         future_to_item = {executor.submit(get_embedding, item): item for item in issues}
         for future in as_completed(future_to_item):
             embedding = future.result()
-            while embedding == "Error":
-                time.sleep(1)
-                embedding = future.result()
             embedding_results.append((embedding, future_to_item[future]))
 
     return embedding_results

--- a/app/v2/content/public_opinion.py
+++ b/app/v2/content/public_opinion.py
@@ -154,8 +154,8 @@ def get_comments_from_clusters(clusters):
     df['total_interaction'] = df['antipathy_count'] + df['sympathy_count'] + df['reply_count']
     df['sympathy_ratio'] = df['sympathy_count'] / (df['antipathy_count'] + 1)
     # 날짜 형식 변환
-    df['date'] = pd.to_datetime(df['date']).dt.date
-
+    #df['date'] = pd.to_datetime(df['date']).dt.date
+    df['date'] = df['date'].astype(str)
     return df
 
 

--- a/app/v2/content/public_opinion.py
+++ b/app/v2/content/public_opinion.py
@@ -172,6 +172,7 @@ def get_word_frequency(comments_df):
     for index, row in sorted_by_sympathy_count.iterrows():
         nouns = okt.nouns(row['contents'])
         nouns = [v for v in nouns if len(v) >= 2]
+        nouns = list(set(nouns))
         for noun in nouns:
             if noun not in keyword_map:
                 keyword_map[noun] = []
@@ -183,7 +184,6 @@ def get_word_frequency(comments_df):
             'comments': comments,
             'count': len(comments)
         })
-
     return word_frequency
 
 

--- a/app/v2/content/public_opinion.py
+++ b/app/v2/content/public_opinion.py
@@ -241,11 +241,12 @@ def get_public_opinion_summary(comments_df):
     comment_text = ''
     for index, row in top_10_comments.iterrows():
         comment_text += '\n' + row['contents']
-
+    if not comment_text:
+        return None
     preset_text = [{"role": "system",
                     "content": "- 댓글을 요약하는 AI 어시스턴트입니다."
                                "- 반드시 댓글 내용에 관한 내용만 출력합니다."
-                               "- 본문의 핵심 내용이 잘 드러나게 정리합니다."
+                               "- 예를 들어, “찬성 의견이 60% 이상입니다” 또는 “주요 우려 사항은 X입니다”와 같은 분석 결과를 제공합니다."
                                "- 최소 300자 이내로 내용을 출력합니다."
                     },
                    {"role": "user", "content": f"{comment_text}"}]

--- a/app/v2/external_request/request_embeding.py
+++ b/app/v2/external_request/request_embeding.py
@@ -29,4 +29,5 @@ class EmbeddingExecutor:
         if res['status']['code'] == '20000':
             return res['result']['embedding']
         else:
+            print("embedding", res['status']['code'])
             return 'Error'

--- a/app/v2/external_request/request_news_comments.py
+++ b/app/v2/external_request/request_news_comments.py
@@ -29,7 +29,7 @@ class RequestNewsComments:
     def get_news_comments_num(url):
         media_id, article_id = parse_url(url)
         if not media_id or not article_id:
-            return None
+            return -1
         try:
             url = f"https://apis.naver.com/commentBox/cbox/web_naver_list_jsonp.json?ticket=news&pool=cbox5&_callback=&lang=ko&country=KR&objectId=news{media_id}%2C{article_id}&pageSize={5}"
             html = requests.get(url, headers=header)

--- a/app/v2/external_request/request_news_comments.py
+++ b/app/v2/external_request/request_news_comments.py
@@ -36,6 +36,7 @@ class RequestNewsComments:
             comment_text = json.loads(html.text.replace('_callback(', '')[:-2])
             return int(comment_text['result']['count']['comment'])
         except Exception as e:
+            print("error in get_news_comments_num")
             return -1
 
     @staticmethod
@@ -55,4 +56,5 @@ class RequestNewsComments:
                         for comment_info in comment_text['result']['commentList']]
             return comments
         except Exception as e:
+            print("error in get_news_comments")
             return None

--- a/app/v2/external_request/request_news_summary.py
+++ b/app/v2/external_request/request_news_summary.py
@@ -31,4 +31,5 @@ def get_news_summary(url):
         news_summary = {'title': json_data['title'], 'summary': json_data['summary']}
         return news_summary
     except Exception as e:
+        print("error in news_summary")
         return None

--- a/app/v2/recently_added/get_recently_added.py
+++ b/app/v2/recently_added/get_recently_added.py
@@ -43,3 +43,17 @@ def get_recently_added_sep():
         for item in items[:limit]
     ]
     return recently_added_list
+
+
+def get_recently_added_all():
+    query = ContentHash.find()
+    items = sorted([content for content in query], key=lambda x: x.created_at, reverse=True)
+
+    recently_added_list = [
+        RecentlyAdded(
+            keyword=item.keyword,
+            elapsed_time=calculate_elapsed_time(item.created_at)
+        )
+        for item in items[:]
+    ]
+    return recently_added_list

--- a/app/v2/redis/model/api_call_count.py
+++ b/app/v2/redis/model/api_call_count.py
@@ -1,0 +1,8 @@
+from datetime import datetime
+
+from redis_om import JsonModel
+
+
+class APICallCount(JsonModel):
+    count: int
+    last_call: datetime

--- a/app/v2/redis/model/content_hash.py
+++ b/app/v2/redis/model/content_hash.py
@@ -1,17 +1,76 @@
+import base64
 from typing import List, Dict, Any
 
 from redis_om import Field, JsonModel
 
+import zlib
+import json
+
+
+def compress_data(data: Any) -> str:
+    json_data = json.dumps(data)
+    compressed_data = zlib.compress(json_data.encode('utf-8'))
+    base64_data = base64.b64encode(compressed_data).decode('utf-8')
+    return base64_data
+
+def decompress_data(base64_data: str) -> Any:
+    compressed_data = base64.b64decode(base64_data)
+    decompressed_data = zlib.decompress(compressed_data).decode('utf-8')
+    return json.loads(decompressed_data)
+
+
+# class ContentHash(JsonModel):
+#     keyword: str = Field(index=True)
+#     created_at: str = Field(index=True)
+#     keyword_trend_data: List[Dict[str, Any]]
+#     keyword_suggestions_data: List[Dict[str, Any]]
+#     public_opinion_sentiment: Any
+#     public_opinion_word_frequency: Any
+#     table_of_contents: List[Dict[str, Any]]
+#     body: List[Dict[str, Any]]
+#     table_of_public_opinion: Any
+#     public_opinion_trend: Any
+#     public_opinion_summary: Any
 
 class ContentHash(JsonModel):
     keyword: str = Field(index=True)
     created_at: str = Field(index=True)
-    keyword_trend_data: List[Dict[str, Any]]
-    keyword_suggestions_data: List[Dict[str, Any]]
-    public_opinion_sentiment: Any
-    public_opinion_word_frequency: Any
-    table_of_contents: List[Dict[str, Any]]
-    body: List[Dict[str, Any]]
-    table_of_public_opinion: Any
-    public_opinion_trend: Any
-    public_opinion_summary: Any
+    keyword_trend_data: Any  # 압축된 데이터로 저장
+    keyword_suggestions_data: Any  # 압축된 데이터로 저장
+    public_opinion_sentiment: Any  # 압축된 데이터로 저장
+    public_opinion_word_frequency: Any  # 압축된 데이터로 저장
+    table_of_contents: Any  # 압축된 데이터로 저장
+    body: Any  # 압축된 데이터로 저장
+    table_of_public_opinion: Any  # 압축된 데이터로 저장
+    public_opinion_trend: Any  # 압축된 데이터로 저장
+    public_opinion_summary: Any  # 압축된 데이터로 저장
+
+    def save(self, *args, **kwargs):
+        # 저장하기 전에 데이터를 압축합니다.
+        self.keyword_trend_data = compress_data(self.keyword_trend_data)
+        self.keyword_suggestions_data = compress_data(self.keyword_suggestions_data)
+        self.public_opinion_sentiment = compress_data(self.public_opinion_sentiment)
+        self.public_opinion_word_frequency = compress_data(self.public_opinion_word_frequency)
+        self.table_of_contents = compress_data(self.table_of_contents)
+        self.body = compress_data(self.body)
+        self.table_of_public_opinion = compress_data(self.table_of_public_opinion)
+        self.public_opinion_trend = compress_data(self.public_opinion_trend)
+        self.public_opinion_summary = compress_data(self.public_opinion_summary)
+
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def get_decompressed(cls, pk: str):
+        # 압축을 해제하여 데이터를 가져옵니다.
+        instance = cls.get(pk)
+        instance.keyword_trend_data = decompress_data(instance.keyword_trend_data)
+        instance.keyword_suggestions_data = decompress_data(instance.keyword_suggestions_data)
+        instance.public_opinion_sentiment = decompress_data(instance.public_opinion_sentiment)
+        instance.public_opinion_word_frequency = decompress_data(instance.public_opinion_word_frequency)
+        instance.table_of_contents = decompress_data(instance.table_of_contents)
+        instance.body = decompress_data(instance.body)
+        instance.table_of_public_opinion = decompress_data(instance.table_of_public_opinion)
+        instance.public_opinion_trend = decompress_data(instance.public_opinion_trend)
+        instance.public_opinion_summary = decompress_data(instance.public_opinion_summary)
+
+        return instance

--- a/app/v2/redis/redis_util.py
+++ b/app/v2/redis/redis_util.py
@@ -37,12 +37,12 @@ def save_to_caching(content: Content, background_tasks: BackgroundTasks):
 
 
 def save_creating(keyword: str):
-    KST = pytz.timezone('Asia/Seoul')
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     creating_hash = CreatingHash(keyword=keyword, started_at=now)
 
     creating_hash.save()
     creating_hash.expire(600)
+
 
 def read_creating(keyword: str):
     Migrator().run()
@@ -51,6 +51,7 @@ def read_creating(keyword: str):
         return None
     creating = [CreatingHash.get(key.pk) for key in keys]
     return creating[0]
+
 
 def remove_creating(keyword: str):
     Migrator().run()

--- a/app/v2/redis/redis_util.py
+++ b/app/v2/redis/redis_util.py
@@ -32,6 +32,7 @@ def save_to_caching(content: Content, background_tasks: BackgroundTasks):
                                public_opinion_trend=content.public_opinion_trend,
                                public_opinion_summary=content.public_opinion_summary)
     content_hash.save()
+    content_hash.expire(7200)
     background_tasks.add_task(move_to_db_and_delete_from_cache, content_hash.pk)
 
 
@@ -41,6 +42,7 @@ def save_creating(keyword: str):
     creating_hash = CreatingHash(keyword=keyword, started_at=now)
 
     creating_hash.save()
+    creating_hash.expire(600)
 
 def read_creating(keyword: str):
     Migrator().run()
@@ -66,14 +68,3 @@ def read_cache_content(keyword: str):
         return None
     contents = [ContentHash.get(key.pk) for key in keys]
     return contents[0]
-
-def db_read(keyword: str):
-    keys = db_redis.keys(f"content:*")
-    contents = []
-    for key in keys:
-        content = db_redis.hgetall(key)
-        if content and content['keyword'] == keyword:
-            contents.append(content)
-    if not contents:
-        return None
-    return contents

--- a/app/v2/redis/redis_util.py
+++ b/app/v2/redis/redis_util.py
@@ -33,7 +33,6 @@ def save_to_caching(content: Content, background_tasks: BackgroundTasks):
                                public_opinion_summary=content.public_opinion_summary)
     content_hash.save()
     content_hash.expire(7200)
-    background_tasks.add_task(move_to_db_and_delete_from_cache, content_hash.pk)
 
 
 def save_creating(keyword: str):
@@ -62,10 +61,21 @@ def remove_creating(keyword: str):
         CreatingHash.delete(key.pk)
 
 
+# def read_cache_content(keyword: str):
+#     Migrator().run()
+#     keys = ContentHash.find(ContentHash.keyword == keyword).all()
+#     if not keys:
+#         return None
+#     contents = [ContentHash.get(key.pk) for key in keys]
+#     return contents[0]
+
 def read_cache_content(keyword: str):
-    Migrator().run()
-    keys = ContentHash.find(ContentHash.keyword == keyword).all()
+    Migrator().run()  # 마이그레이션 실행
+    keys = ContentHash.find(ContentHash.keyword == keyword).all()  # 키워드에 해당하는 모든 키 찾기
+
     if not keys:
         return None
-    contents = [ContentHash.get(key.pk) for key in keys]
-    return contents[0]
+
+    # 첫 번째 키에 해당하는 데이터를 압축 해제하여 반환
+    content = ContentHash.get_decompressed(keys[0].pk)
+    return content

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from fastapi import FastAPI, Request, BackgroundTasks
 from fastapi.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 from app.v1.request_external_api import get_google_trend_daily_rank
+from app.v2.config.rate_limit import check_rate_limit
 from app.v2.content import get_content, create_content
 from app.v2.creating.get_creating import get_creating_sep
 from app.v2.keyword_rank import get_keyword_rank
@@ -76,6 +77,10 @@ async def render_report_v2(q: str, request: Request, background_task: Background
     content = get_content(q)
     keyword_rank = get_keyword_rank()
     if not content:
+        rate_limit_info = check_rate_limit()
+        if not rate_limit_info['status']:
+            return rate_limit_info['message']
+
         background_task.add_task(create_content, q, background_task)
         return templates_v2.TemplateResponse(
             request=request, name="creating.html", context={

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ from app.v2.config.rate_limit import check_rate_limit
 from app.v2.content import get_content, create_content
 from app.v2.creating.get_creating import get_creating_sep
 from app.v2.keyword_rank import get_keyword_rank
-from app.v2.recently_added.get_recently_added import get_recently_added_sep
+from app.v2.recently_added.get_recently_added import get_recently_added_sep, get_recently_added_all
 
 from app.v2.redis.redis_connection import connect_redis
 
@@ -28,6 +28,7 @@ app = FastAPI(lifespan=lifespan)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 templates_v1 = Jinja2Templates(directory="templates/v1")
 templates_v2 = Jinja2Templates(directory="templates/v2")
+
 
 # @app.get("/")
 # async def render_main(request: Request):
@@ -73,7 +74,6 @@ async def render_main_v2(request: Request):
 
 @app.get("/report")
 async def render_report_v2(q: str, request: Request, background_task: BackgroundTasks):
-
     content = get_content(q)
     keyword_rank = get_keyword_rank()
     if not content:
@@ -96,12 +96,25 @@ async def render_report_v2(q: str, request: Request, background_task: Background
         }
     )
 
+
 @app.get("/api/recent-add-sep")
-async def get_recent_add():
+async def get_recent_add_sep():
     return get_recently_added_sep()
+
 
 @app.get("/api/creating-sep")
 async def creating_sep():
     return get_creating_sep()
+
+
+@app.get("/recently-added")
+async def get_recently_add_all(request: Request):
+    return templates_v2.TemplateResponse(
+        request=request, name="recently_added_all.html", context={
+            'recently_added_all': get_recently_added_all(),
+            'keyword_rank': get_keyword_rank()
+        }
+    )
+
 
 uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/templates/v2/recently_added_all.html
+++ b/templates/v2/recently_added_all.html
@@ -11,6 +11,7 @@
 <div class="flex gap-10" style="margin: 1rem 15% 0 15%">
     <div style="width: 80%">
         <div class="bg-white flex flex-col rounded p-6" style="border: 1px solid #ccc">
+            <span class="text-xl font-bold mb-4">최근 생성</span>
             <div class="flex flex-col items-center">
                 <table class="min-w-full bg-white">
                     <thead>

--- a/templates/v2/recently_added_all.html
+++ b/templates/v2/recently_added_all.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Webpage Layout</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100">
+{% include "header.html" %}
+<div class="flex gap-10" style="margin: 1rem 15% 0 15%">
+    <div style="width: 80%">
+        <div class="bg-white flex flex-col rounded p-6" style="border: 1px solid #ccc">
+            <div class="flex flex-col items-center">
+                <table class="min-w-full bg-white">
+                    <thead>
+                    <tr class="bg-gray-100 text-gray-800 uppercase text-sm leading-normal">
+                        <th class="py-3 px-6 text-left">키워드</th>
+                        <th class="py-3 px-6 text-left">
+                            <div class="flex gap-1 items-center">
+                                <span>생성 시간</span>
+                            </div>
+                        </th>
+                    </tr>
+                    </thead>
+                    <tbody class="text-gray-600 text-sm font-light">
+
+                    {% for item in recently_added_all %}
+                    <tr class="border-b border-gray-200 hover:bg-gray-100">
+                        <td class="py-3 px-6 text-left"><a href="/report?q={{ item.keyword }}">{{ item.keyword }}</a>
+                        </td>
+                        <td class="py-3 px-6 text-left">{{ item.elapsed_time }}</td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="flex flex-col gap-3">
+        <div>
+            {% include "keyword_rank.html" %}
+        </div>
+        <div>
+            {% include "recently_added_list.html" %}
+        </div>
+        <div>
+            {% include "creating_list.html" %}
+        </div>
+
+    </div>
+</div>
+<script>
+    window.onload = () => {
+        fetchChanges();
+        fetchCreating();
+        setInterval(fetchChanges, 15000)
+        setInterval(fetchCreating, 15000)
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 🌁 배경
close  #44 

## ✅ 수정 내역
* 일일 최대 보고서 생성 횟수를 제한 (300회)
* entertain, sports 뉴스가 제외되는 현상 수정
* 각 보고서는 최대 2시간 유지되며, 이후 삭제되도록 수정
* 모든 최근 생성 리스트를 볼 수 있도록 시각화 (GET /recently-added)
* embedding 에 대한 처리 실패 (너무 많은 요청) 재시도 하도록 수정
* redis에 보고서를 저장할 때 zlib으로 압축 적용 (평균 500kb -> 70kb 로 감소), 해당 변경 사항으로 요청 속도 개선
* 여론 조회 시 한 키워드에 중복 되는 댓글이 조회 되는 현상 수정 

## 📕 리뷰 노트
